### PR TITLE
Implement SPI Transmit

### DIFF
--- a/boards/tinyfpga.pcf
+++ b/boards/tinyfpga.pcf
@@ -39,7 +39,7 @@
 
 # Left side of board
 set_io --warn-no-port SCK A2 # PIN_1
-set_io --warn-no-port SSEL A1 # PIN_2
+set_io --warn-no-port CS A1 # PIN_2
 set_io --warn-no-port COPI B1 # PIN_3
 set_io --warn-no-port CIPO C2 # PIN_4
 set_io --warn-no-port PIN_5 C1

--- a/spi.v
+++ b/spi.v
@@ -1,282 +1,119 @@
 `default_nettype none
 
-// Derived from: https://github.com/nandland/spi-slave
-// MIT License
+// Mode 0 8Bit transfer SPI Peripheral implementation
+module SPI (
+    input            clk,
+    input            SCK,
+    input            CS,
+    input            COPI,
+    output           CIPO,
+    input      [7:0] tx_byte,
+    output reg [7:0] rx_byte,
+    output reg       rx_byte_ready
+);
 
-// Copyright (c) 2019 russell-merrick
+  // Tegisters to sync IO with FPGA clock
+  reg [2:0] SCKr;
+  reg [2:0] CSr;
+  reg [1:0] COPIr;
 
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+  // count the number of RX and TX bits RX incrments on rising, TX on falling SCK edge
+  reg [2:0] rxbitcnt = 3'b000; // counts up
+  reg [2:0] txbitcnt = 3'b111; // counts down
 
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
+  // Assign wires for SPI events, registers assigned in block below
+  wire SCK_risingedge = (SCKr[2:1] == 2'b01);
+  wire SCK_fallingedge = (SCKr[2:1] == 2'b10);
+  wire CS_active = ~CSr[1];  // active low
+  wire COPI_data = COPIr[1];
+  // CIPO pin (tristated per convention)
+  assign CIPO = (CS_active) ? tx_byte[txbitcnt] : 1'bZ;
 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+  always @(posedge clk) begin
 
+    // Use a 3 bit shift register to sync CS, COPI, CIPO, with FPGA clock
+    SCKr <= {SCKr[1:0], SCK};
+    CSr <= {CSr[1:0], CS};
+    COPIr <= {COPIr[0], COPI};
 
-///////////////////////////////////////////////////////////////////////////////
-// Description: SPI (Serial Peripheral Interface) Slave
-//              Creates slave based on input configuration.
-//              Receives a byte one bit at a time on MOSI
-//              Will also push out byte data one bit at a time on MISO.
-//              Any data on input byte will be shipped out on MISO.
-//              Supports multiple bytes per transaction when CS_n is kept
-//              low during the transaction.
-//
-// Note:        i_Clk must be at least 4x faster than i_SPI_Clk
-//              MISO is tri-stated when not communicating.  Allows for multiple
-//              SPI Slaves on the same interface.
-//
-// Parameters:  SPI_MODE, can be 0, 1, 2, or 3.  See above.
-//              Can be configured in one of 4 modes:
-//              Mode | Clock Polarity (CPOL/CKP) | Clock Phase (CPHA)
-//               0   |             0             |        0
-//               1   |             0             |        1
-//               2   |             1             |        0
-//               3   |             1             |        1
-//              More info: https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Mode_numbers
-///////////////////////////////////////////////////////////////////////////////
+    if (CS_active) begin
+      // Recieve increment on rising edge
+      if (SCK_risingedge) begin
+        rxbitcnt <= rxbitcnt + 3'b001;
+        // Shift in Recieved bits
+        rx_byte <= {rx_byte[6:0], COPI_data};
 
-// n.b
-// The new language for SPI pin labeling recommends the use of SDO/SDI (Serial Data Out/In)
-// for single-role hardware, and COPI/CIPO for “Controller Out, Peripheral In” and
-// “Controller In, Peripheral Out” for devices that can be either the controller or
-// the peripheral. The change also updates the “SS” (Slave Select) pin to use “CS” (Chip Select).
-
-module SPI_Slave
-  #(parameter SPI_MODE = 0)
-  (
-   // Control/Data Signals,
-   input            i_Rst_L,    // FPGA Reset, active low
-   input            i_Clk,      // FPGA Clock
-   output reg       o_RX_DV,    // Data Valid pulse (1 clock cycle)
-   output reg [7:0] o_RX_Byte,  // Byte received on MOSI
-   input            i_TX_DV,    // Data Valid pulse to register i_TX_Byte
-   input  [7:0]     i_TX_Byte,  // Byte to serialize to MISO.
-
-   // SPI Interface
-   input      i_SPI_Clk,
-   output reg o_SPI_MISO,
-   input      i_SPI_MOSI,
-   input      i_SPI_CS_n // active low
-   );
-
-
-  // SPI Interface (All Runs at SPI Clock Domain)
-  wire w_CPOL;     // Clock polarity
-  wire w_CPHA;     // Clock phase
-  wire w_SPI_Clk;  // Inverted/non-inverted depending on settings
-  wire w_SPI_MISO_Mux;
-
-  reg [2:0] r_RX_Bit_Count;
-  reg [2:0] r_TX_Bit_Count;
-  reg [7:0] r_Temp_RX_Byte;
-  reg [7:0] r_RX_Byte;
-  reg r_RX_Done, r2_RX_Done, r3_RX_Done;
-  reg [7:0] r_TX_Byte;
-  reg r_SPI_MISO_Bit, r_Preload_MISO;
-
-  // CPOL: Clock Polarity
-  // CPOL=0 means clock idles at 0, leading edge is rising edge.
-  // CPOL=1 means clock idles at 1, leading edge is falling edge.
-  assign w_CPOL  = (SPI_MODE == 2) | (SPI_MODE == 3);
-
-  // CPHA: Clock Phase
-  // CPHA=0 means the "out" side changes the data on trailing edge of clock
-  //              the "in" side captures data on leading edge of clock
-  // CPHA=1 means the "out" side changes the data on leading edge of clock
-  //              the "in" side captures data on the trailing edge of clock
-  assign w_CPHA  = (SPI_MODE == 1) | (SPI_MODE == 3);
-
-  assign w_SPI_Clk = w_CPHA ? ~i_SPI_Clk : i_SPI_Clk;
-
-
-
-  // Purpose: Recover SPI Byte in SPI Clock Domain
-  // Samples line on correct edge of SPI Clock
-  always @(posedge w_SPI_Clk or posedge i_SPI_CS_n)
-  begin
-    if (i_SPI_CS_n)
-    begin
-      r_RX_Bit_Count <= 0;
-      r_RX_Done      <= 1'b0;
-    end
-    else
-    begin
-      r_RX_Bit_Count <= r_RX_Bit_Count + 1;
-
-      // Receive in LSB, shift up to MSB
-      r_Temp_RX_Byte <= {r_Temp_RX_Byte[6:0], i_SPI_MOSI};
-
-      if (r_RX_Bit_Count == 3'b111)
-      begin
-        r_RX_Done <= 1'b1;
-        r_RX_Byte <= {r_Temp_RX_Byte[6:0], i_SPI_MOSI};
-      end
-      else if (r_RX_Bit_Count == 3'b010)
-      begin
-        r_RX_Done <= 1'b0;
+        // Trigger Byte recieved
+        rx_byte_ready <= (rxbitcnt[2:0] == 3'b111);
       end
 
-    end // else: !if(i_SPI_CS_n)
-  end // always @ (posedge w_SPI_Clk or posedge i_SPI_CS_n)
-
-
-
-  // Purpose: Cross from SPI Clock Domain to main FPGA clock domain
-  // Assert o_RX_DV for 1 clock cycle when o_RX_Byte has valid data.
-  always @(posedge i_Clk or negedge i_Rst_L)
-  begin
-    if (~i_Rst_L)
-    begin
-      r2_RX_Done <= 1'b0;
-      r3_RX_Done <= 1'b0;
-      o_RX_DV    <= 1'b0;
-      o_RX_Byte  <= 8'h00;
-    end
-    else
-    begin
-      // Here is where clock domains are crossed.
-      // This will require timing constraint created, can set up long path.
-      r2_RX_Done <= r_RX_Done;
-
-      r3_RX_Done <= r2_RX_Done;
-
-      if (r3_RX_Done == 1'b0 && r2_RX_Done == 1'b1) // rising edge
-      begin
-        o_RX_DV   <= 1'b1;  // Pulse Data Valid 1 clock cycle
-        o_RX_Byte <= r_RX_Byte;
+      // Transmit increment
+      if (SCK_fallingedge) begin
+        txbitcnt <= txbitcnt - 3'b001; // rolls over
       end
-      else
-      begin
-        o_RX_DV <= 1'b0;
-      end
-    end // else: !if(~i_Rst_L)
-  end // always @ (posedge i_Bus_Clk)
-
-
-  // Control preload signal.  Should be 1 when CS is high, but as soon as
-  // first clock edge is seen it goes low.
-  always @(posedge w_SPI_Clk or posedge i_SPI_CS_n)
-  begin
-    if (i_SPI_CS_n)
-    begin
-      r_Preload_MISO <= 1'b1;
-    end
-    else
-    begin
-      r_Preload_MISO <= 1'b0;
+    end else begin
+      // Reset counts if a txfer is interrupted for some reason
+      rxbitcnt <= 3'b000;
+      txbitcnt <= 3'b111;
     end
   end
 
-
-  // Purpose: Transmits 1 SPI Byte whenever SPI clock is toggling
-  // Will transmit read data back to SW over MISO line.
-  // Want to put data on the line immediately when CS goes low.
-  always @(posedge w_SPI_Clk or posedge i_SPI_CS_n)
-  begin
-    if (i_SPI_CS_n)
-    begin
-      r_TX_Bit_Count <= 3'b111;  // Send MSb first
-      r_SPI_MISO_Bit <= r_TX_Byte[3'b111];  // Reset to MSb
-    end
-    else
-    begin
-      r_TX_Bit_Count <= r_TX_Bit_Count - 1;
-
-      // Here is where data crosses clock domains from i_Clk to w_SPI_Clk
-      // Can set up a timing constraint with wide margin for data path.
-      r_SPI_MISO_Bit <= r_TX_Byte[r_TX_Bit_Count];
-
-    end // else: !if(i_SPI_CS_n)
-  end // always @ (negedge w_SPI_Clk or posedge i_SPI_CS_n_SW)
-
-
-  // Purpose: Register TX Byte when DV pulse comes.  Keeps registed byte in
-  // this module to get serialized and sent back to master.
-  always @(posedge i_Clk or negedge i_Rst_L)
-  begin
-    if (~i_Rst_L)
-    begin
-      r_TX_Byte <= 8'h00;
-    end
-    else
-    begin
-      if (i_TX_DV)
-      begin
-        r_TX_Byte <= i_TX_Byte;
-      end
-    end // else: !if(~i_Rst_L)
-  end // always @ (posedge i_Clk or negedge i_Rst_L)
-
-  // Preload MISO with top bit of send data when preload selector is high.
-  // Otherwise just send the normal MISO data
-  assign w_SPI_MISO_Mux = r_Preload_MISO ? r_TX_Byte[3'b111] : r_SPI_MISO_Bit;
-
-  // Tri-statae MISO when CS is high.  Allows for multiple slaves to talk.
-  assign o_SPI_MISO = i_SPI_CS_n ? 1'bZ : w_SPI_MISO_Mux;
-
-endmodule // SPI_Slave
+endmodule
 
 
 
 // 32 bit word SPI wrapper for Little endian 8 bit transfers
 //
 module SPIWord (
-    input         clk,
-    input SCK,
-    input SSEL,
-    input MOSI,
-    output MISO,
-    input [63:0] word_send_data,
-    output reg       word_received,
-    output [63:0] word_data_received
+    input             clk,
+    input             SCK,
+    input             CS,
+    input             COPI,
+    output            CIPO,
+    input [63:0]      word_send_data,
+    output            word_received,
+    output reg [63:0] word_data_received
 );
 
   // SPI Initialization
   // The standard unit of transfer is 8 bits, MSB
-  wire byte_received;  // high when a byte has been received
-  reg [7:0] byte_data_received;
-  reg [7:0] send_data;
-  wire reset;
-  assign reset = 1;
-  reg SPI_TX_DV;
-  SPI_Slave spi0 (
-            .i_Rst_L(reset),
-            .i_Clk(clk),
-            .o_RX_DV(byte_received),
-            .o_RX_Byte(byte_data_received),
-            .i_TX_DV(SPI_TX_DV),
-            .i_TX_Byte(send_data),
-            .i_SPI_Clk(SCK),
-            .o_SPI_MISO(MISO),
-            .i_SPI_MOSI(MOSI),
-            .i_SPI_CS_n(SSEL));
+  wire rx_byte_ready;  // high when a byte has been received
+  reg [7:0] rx_byte;
+  reg [7:0] tx_byte;
+  SPI spi0 (.clk(clk),
+            .CS(CS),
+            .SCK(SCK),
+            .CIPO(CIPO),
+            .COPI(COPI),
+            .tx_byte(tx_byte),
+            .rx_byte(rx_byte),
+            .rx_byte_ready(rx_byte_ready));
 
-  reg [4:0] byte_count = 0;
+  reg [3:0] byte_count = 0;
 
-  // TODO Send does not work
-  always @(posedge byte_received) begin
+  // Recieve Shift Register
+  always @(posedge rx_byte_ready) begin
     byte_count = (byte_count == 8) ? 1 : byte_count + 1;
-    word_data_received = {byte_data_received[7:0], word_data_received[63:8]};
-    send_data = 8'h00;
+    word_data_received = {rx_byte[7:0], word_data_received[63:8]};
   end
 
+  assign word_received = (byte_count == 8);
+
+  // Transmit data assignment
   always @(posedge clk) begin
-    word_received <= (byte_count == 8);
-    //if (byte_count == 4) send_data[7:0] <= word_send_data[7:0];
-    //if (byte_count == 1) send_data[7:0] <= word_send_data[15:8];
-    //if (byte_count == 2) send_data[7:0] <= word_send_data[23:16];
-    //if (byte_count == 3) send_data[7:0] <= word_send_data[31:24];
+    case (byte_count)
+        0: tx_byte[7:0] = word_send_data[7:0]; // This should only hit at initialization
+        1: tx_byte[7:0] = word_send_data[15:8];
+        2: tx_byte[7:0] = word_send_data[23:16];
+        3: tx_byte[7:0] = word_send_data[31:24];
+        4: tx_byte[7:0] = word_send_data[39:32];
+        5: tx_byte[7:0] = word_send_data[47:40];
+        6: tx_byte[7:0] = word_send_data[55:48];
+        7: tx_byte[7:0] = word_send_data[63:56];
+        8: tx_byte[7:0] = word_send_data[7:0];
+        `ifdef FORMAL
+          default: assert(0);
+        `endif
+    endcase
   end
 endmodule

--- a/top.v
+++ b/top.v
@@ -8,7 +8,7 @@ module top (
     output LED,  // User/boot LED next to power LED
     output USBPU,  // USB pull-up resistor
     input  SCK,
-    input  SSEL,
+    input  CS,
     input  COPI,
     output CIPO,
     output PIN_8,  // Phase A
@@ -38,9 +38,9 @@ module top (
   SPIWord word_proc (
                 .clk(CLK),
                 .SCK(SCK),
-                .SSEL(SSEL),
-                .MOSI(COPI),
-                .MISO(CIPO),
+                .CS(CS),
+                .COPI(COPI),
+                .CIPO(CIPO),
                 .word_send_data(word_send_data),
                 .word_received(word_received),
                 .word_data_received(word_data_received));


### PR DESCRIPTION
Due to the limitations and possible incorrectness of the selected implementation, the core Byte sender had to be redesigned.
This implements a much simpler mechanism for crossing the clock domain. It also aleviated CIPO preload issues by mapping
the tx_byte register directly to the wire and tristates the pin. Given we are likely to have all TX data a priori this
should be fine. E.g. all TX Bytes are register reads. However this may cause issues as the next byte is started at the
falling edge without any clock delay. This trips up my logic analyser.