### PR TITLE
[steptimer] microopt by making the step tick divisor constant

### DIFF
--- a/boards/tinyfpgabx/tinyfpgabx.v
+++ b/boards/tinyfpgabx/tinyfpgabx.v
@@ -11,5 +11,8 @@
 // Motor Definitions
 `define MOTOR1 DUAL_H_BRIDGE
 
+// Enable constant Step Tick Divisor
+`define CONST_STEP_TICK_DIVISOR 40
+
 // Change the Move Buffer Size. Should be power of two
 //`define MOVE_BUFFER_SIZE 4

--- a/docs/boards.md
+++ b/docs/boards.md
@@ -63,12 +63,19 @@ Active High when move buffer has slots available for send.
 ```
 Toggles when a move in the buffer has completed.
 
-### Move Buffer
+### Step Timer Parameters
 
 ```
 `define MOVE_BUFFER_SIZE 2
 ```
-Changes the default move buffer size. Must be a power of two.
+Changes the default move buffer size. NOTE: Must be a power of two.
+
+```
+`define CONST_STEP_TICK_DIVISOR 40
+```
+
+Enables an immutable step tick divisor. Has a minor reduction in gate count and improvment
+to timing.
 
 ## (.pcf/.lpf) Parameters
 


### PR DESCRIPTION
Simple experiment in the timing crusade I am on. Reduces the LUT count by 25 on Ice40 on the bench, and about a 0.5Mhz timing improvement. 

Probably not worth the extra complexity, but if we need to bump the margins this is here.