### PR TITLE
DDA Refactor part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ RAPCOREFILES := boards/$(BOARD)/$(BOARD).v \
 														quad_enc.v \
 														spi.v \
 														stepper.v \
+														dda_fsm.v \
 														dda_timer.v \
 														rapcore.v) \
 								$(wildcard src/microstepper/*.v)

--- a/src/dda_fsm.v
+++ b/src/dda_fsm.v
@@ -4,12 +4,13 @@
 Manage move buffers and DDA timing length
 */
 module dda_fsm #(parameter buffer_bits = 2,
-                 parameter buffer_size = 1)
+                 parameter buffer_size = 1,
+                 parameter move_duration_bits = 32)
 (
   input clk,
   input resetn,
   input dda_tick,
-  input [63:0] move_duration,
+  input [move_duration_bits-1:0] move_duration,
   output loading_move,
   output executing_move,
   output move_done,
@@ -31,7 +32,7 @@ module dda_fsm #(parameter buffer_bits = 2,
   assign loading_move = finishedmove & processing_move;
   assign executing_move = !finishedmove & processing_move;
 
-  reg [63:0] tickdowncount;
+  reg [move_duration_bits-1:0] tickdowncount;
   reg move_done_r;
   reg finishedmove_r;
   reg [1:0] dda_tick_r;

--- a/src/dda_fsm.v
+++ b/src/dda_fsm.v
@@ -1,0 +1,71 @@
+`default_nettype none
+
+/*
+Manage move buffers and DDA timing length
+*/
+module dda_fsm #(parameter buffer_bits = 2,
+                 parameter buffer_size = 1)
+(
+  input clk,
+  input resetn,
+  input dda_tick,
+  input [63:0] move_duration,
+  output loading_move,
+  output executing_move,
+  output move_done,
+  output [buffer_bits-1:0] moveind,
+  input [buffer_size-1:0] stepready,
+  output buffer_dtr
+);
+
+
+  // Buffer latching
+  reg [`MOVE_BUFFER_SIZE:0] stepfinished;
+
+  assign moveind = moveind_r;
+  reg [buffer_bits-1:0] moveind_r;
+
+  // State managment
+  wire finishedmove = finishedmove_r;
+  wire processing_move = (stepfinished[moveind] ^ stepready[moveind]);
+  assign loading_move = finishedmove & processing_move;
+  assign executing_move = !finishedmove & processing_move;
+
+  reg [63:0] tickdowncount;
+  reg move_done_r;
+  reg finishedmove_r;
+  reg [1:0] dda_tick_r;
+
+  always @(posedge clk) if (!resetn) begin
+    move_done_r <= 0;
+    finishedmove_r <= 1; // set 1 init so we are in 'loading_move'
+    stepfinished <= 0;
+    moveind_r <= 0;
+  end else if (resetn) begin
+
+    if (loading_move) begin
+      tickdowncount <= move_duration;
+      finishedmove_r <= 0;
+    end
+
+    // catch rising edge on DDA tick and downcount
+    dda_tick_r <= {dda_tick_r[0], dda_tick};
+    if (dda_tick_r == 2'b01 && executing_move) begin
+      tickdowncount <= tickdowncount - 1'b1;
+    end
+
+    // Trigger move finished
+    if (tickdowncount == 0 && executing_move) begin
+      finishedmove_r <= 1;
+      move_done_r <= ~move_done_r;
+      moveind_r <= moveind_r + 1'b1;
+      stepfinished[moveind] <= ~stepfinished[moveind]; // flip latch to done
+    end
+  end
+
+  // Buffer flow control outputs
+  assign move_done = move_done_r;
+  assign buffer_dtr = ~(~stepfinished == stepready);
+
+
+endmodule

--- a/src/dda_timer.v
+++ b/src/dda_timer.v
@@ -2,61 +2,32 @@
 
 module dda_timer(
   input resetn,
-  input [63:0] move_duration,
   input [63:0] increment,
   input [63:0] incrementincrement,
-  input processing_move,
-  input loading_move,
-  input executing_move,
-  output finishedmove,
+  input  loading_move,
+  input  executing_move,
   output step,
-  `ifdef HALT
-    input halt,
-  `endif
-  `ifdef MOVE_DONE
-    output move_done,
-  `endif
   input dda_tick,
   input CLK
 );
 
-  // Locals
-  reg [63:0] tickdowncount;  // move down count (clock cycles)
-  reg [7:0] clkaccum;  // intra-tick accumulator
-
   reg signed [63:0] substep_accumulator; // typemax(Int64) - 100 for buffer
   reg signed [63:0] increment_r;
-  reg finishedmove; // flag inidicating a move has been finished, so load next
 
   // Step Trigger condition
   reg step_r;
   assign step = step_r;
 
   always @(posedge CLK) if (!resetn) begin
-    // Locals
-    tickdowncount <= 64'b0;  // move down count (clock cycles)
 
     substep_accumulator <= 64'b0; // typemax(Int64) - 100 for buffer
     increment_r <= 64'b0;
-    finishedmove <= 1; // flag inidicating a move has been finished, so load next
     step_r <= 0;
 
   end else if (resetn) begin
 
-    // HALT line (active low) then reset buffer latch and index
-    // TODO: Should substep accumulator reset?
-    `ifdef HALT
-      if (!halt) begin
-        //moveind <= writemoveind; // match buffer cursor
-        //stepfinished <= stepready; // reset latch
-        finishedmove <= 1; // Puts us back in loading_move
-      end
-    `endif
-
     // Load up the move duration
     if (loading_move) begin
-      tickdowncount <= move_duration;
-      finishedmove <= 0;
       increment_r <= increment;
     end
 
@@ -75,13 +46,6 @@ module dda_timer(
 
         increment_r <= increment_r + incrementincrement;
         substep_accumulator <= substep_accumulator + increment_r;
-
-        // Increment tick accumulators
-        tickdowncount <= tickdowncount - 1'b1;
-        // See if we finished the segment and incrment the buffer
-        if(tickdowncount == 0) begin
-          finishedmove <= 1;
-        end
       end
     end
   end

--- a/src/macro_params.v
+++ b/src/macro_params.v
@@ -20,6 +20,11 @@
 `define DEFAULT_TIMER_WIDTH 8
 `endif
 
+// Set the unsigned int size of the move duration register
+`ifndef MOVE_DURATION_BITS
+`define MOVE_DURATION_BITS 32
+`endif
+
 // Default Mosfet Active Polarity
 `ifndef DEFAULT_BRIDGE_INVERTING
 `define DEFAULT_BRIDGE_INVERTING 1

--- a/src/rapcore.v
+++ b/src/rapcore.v
@@ -1,7 +1,8 @@
 `default_nettype none
 
 module rapcore #(
-  parameter motor_count = `MOTOR_COUNT
+  parameter motor_count = `MOTOR_COUNT,
+  parameter move_duration_bits = `MOVE_DURATION_BITS
   )(
     `ifdef LED
       output wire [`LED:1] LED,
@@ -211,7 +212,8 @@ module rapcore #(
   // SPI State Machine
   //
 
-  spi_state_machine #(.motor_count(motor_count)) spifsm
+  spi_state_machine #(.motor_count(motor_count),
+                      .move_duration_bits(move_duration_bits)) spifsm
   (
     `ifdef LA_IN
       .LA_IN(LA_IN),

--- a/symbiyosys.sby
+++ b/symbiyosys.sby
@@ -9,6 +9,7 @@ read -formal formal_config.v
 read -formal macro_params.v
 read -formal constants.v
 read -formal clock_divider.v
+read -formal dda_fsm.v
 read -formal dda_timer.v
 read -formal spi.v
 read -formal stepper.v
@@ -32,6 +33,7 @@ boards/formal_config.v
 src/macro_params.v
 src/constants.v
 src/clock_divider.v
+src/dda_fsm.v
 src/dda_timer.v
 src/spi.v
 src/stepper.v


### PR DESCRIPTION
This removes all buffer and duration counting from the `dda_timer` module. In its place we now use a `dda_fsm` module which handles move duration downcounting, register load events, and buffer latching events.

~This should also make it easier to switch the `move_duration` count to an arbitrary bit length for further savings if required.~ Implemented. ATM G2 uses 32 bit durations whereas rapcores uses 64 bits. 32 bits @400khz DDA gives maximum duration of 5368 seconds, which should be more than sufficient for most applications.

LUT use is down on tinyfpgabx target from 70% on main to ~58%~ 55% with this refactor and 32 bit move_duration. 