### PR TITLE
[ci] add bitstream and log artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v2
+  
     - uses: cachix/install-nix-action@v12
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -24,3 +26,10 @@ jobs:
       run: nix-shell --command 'make verilator-cdc'
     - name: reg initialization
       run: ./etc/reginit.sh
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: RAPcores Build
+        path: |
+          ./build/*.bit
+          ./logs


### PR DESCRIPTION
CI builds on GitHub actions will now produce bitstreams and logs that can be downloaded.