### PR TITLE
[ci/nix] add unstable channel nix-shell and test on CI

### DIFF
--- a/.github/workflows/tooling-next.yml
+++ b/.github/workflows/tooling-next.yml
@@ -1,0 +1,34 @@
+name: "RAPcores next tooling"
+on:
+  pull_request:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+  
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: TinyFPGABX Flow
+      run: nix-shell --command 'make BOARD=tinyfpgabx' shell-unstable.nix
+    - name: ULX3S Flow
+      run: nix-shell --command 'make BOARD=ulx3s' shell-unstable.nix
+    - name: RAPBo Flow
+      run: nix-shell --command 'make BOARD=rapbo' shell-unstable.nix
+    - name: ECP5 Eval Flow
+      run: nix-shell --command 'make BOARD=ecp5evn' shell-unstable.nix
+    - name: Formal Verification
+      run: nix-shell --command 'make formal' shell-unstable.nix
+    - name: iverilog parse compat
+      run: nix-shell --command 'make iverilog-parse' shell-unstable.nix
+    - name: verilator CDC
+      run: nix-shell --command 'make verilator-cdc' shell-unstable.nix
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: RAPcores-build-unstable
+        path: |
+          ./build/*.bit
+          ./logs

--- a/shell-unstable.nix
+++ b/shell-unstable.nix
@@ -1,0 +1,22 @@
+
+# nix.shell: RAPCore Development Environment
+# Latest unstable nix-shell
+
+with import <nixpkgs> {};
+
+let
+
+  # These are all the packages that will be available inside the nix-shell
+  # environment.
+  buildInputs = with pkgs;
+    # these are generally useful packages for tests, verification, synthesis
+    # and deployment, etc
+    [ yosys verilog verilator symbiyosys nextpnr icestorm trellis
+      yices tinyprog fujprog openocd
+    ];
+
+# For other formal modes, may need:
+# z3 boolector
+
+# Export a usable shell environment
+in runCommand "rapcore-shell" { inherit buildInputs; } ""


### PR DESCRIPTION
These types of "okay if fail" unstable tests are not supported by GitHub actions. So a big red "X" may show up. 

To test on latest unstable nixpkgs (seems to be updated a few times per month):
```
nix-shell shell-unstable.nix
```

The purpose is to track the next upstream in our tool chain, e.g. improvements, report regressions, discover bugs, etc.