### PR TITLE
Refactor Module Hierarchy

### DIFF
--- a/boards/rapbo/rapbo.v
+++ b/boards/rapbo/rapbo.v
@@ -40,9 +40,9 @@
 //`define LA_IN 2
 
 // Logic Analyzer IO for rapcore.v can be set here
-`define TOP_LA\
-  assign LA_OUT[1] = dir; \
-  assign LA_OUT[2] = analog_cmp2;
+//`define TOP_LA\
+//  assign LA_OUT[1] = dir; \
+//  assign LA_OUT[2] = analog_cmp2;
 
 // Logic Analyzer IO for microstepper_top.v can be set here
 //`define MICROSTEPPER_LA\

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -71,17 +71,6 @@ module spi_state_machine #(
   input spi_clock
 );
 
-  `ifdef SPIPLL
-    // PLL for SPI Bus
-    wire spi_clock;
-    wire spipll_locked;
-    spi_pll spll (.clock_in(CLK),
-                  .clock_out(spi_clock),
-                  .locked(spipll_locked));
-  `else
-    wire spi_clock = CLK;
-  `endif
-
   // Word handler
   // The system operates on 64 bit little endian words
   // This should make it easier to send 64 bit chunks from the host controller
@@ -213,7 +202,6 @@ module spi_state_machine #(
   `endif
 
   `ifdef ULTIBRIDGE
-    genvar i;
     generate
       for (i=0; i<motor_count; i=i+1) begin
         microstepper_top microstepper0(


### PR DESCRIPTION
Simple reorg to avoid implementing a bus between modules. I may move the SPI bus out as well so the FSM is more agnostic to the bus implementation.

![module-layout](https://user-images.githubusercontent.com/2086412/108453607-cdb72900-7238-11eb-978a-4dd2528c94f9.png)
