### PR TITLE
RFC/WIP: Bitpack data to store in single BRAM

### DIFF
--- a/src/constants.v
+++ b/src/constants.v
@@ -14,3 +14,11 @@
 `define CMD_API_VERSION 8'hfe
 `define CMD_CHARGEPUMP 8'h31
 `define CMD_BRIDGEINVERT 8'h32
+
+
+//
+// Bit packed memory offsets for configs
+//
+
+`define MEM_MICROSTEPS 15:8
+`define MEM_CURRENT 7:0

--- a/src/constants.v
+++ b/src/constants.v
@@ -14,11 +14,3 @@
 `define CMD_API_VERSION 8'hfe
 `define CMD_CHARGEPUMP 8'h31
 `define CMD_BRIDGEINVERT 8'h32
-
-
-//
-// Bit packed memory offsets for configs
-//
-
-`define MEM_MICROSTEPS 15:8
-`define MEM_CURRENT 7:0

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -133,8 +133,8 @@ module spi_state_machine #(
   // Stepper Configs
   //
 
-  reg [7:0] microsteps [0:motor_count-1];
-  reg [7:0] current [0:motor_count-1];
+  reg [15:0] config_memory [0:motor_count-1]; // [15:8] -> microsteps [7:0] current
+
   reg [9:0] config_offtime [0:motor_count-1];
   reg [7:0] config_blanktime [0:motor_count-1];
   reg [9:0] config_fastdecay_threshold [0:motor_count-1];
@@ -166,8 +166,8 @@ module spi_state_machine #(
                       .dir (dir[i]),
                       .enable (enable[i]),
                       .brake  (brake[i]),
-                      .microsteps (microsteps[i]),
-                      .current (current[i]),
+                      .microsteps (config_memory[i][`MEM_MICROSTEPS]),
+                      .current (config_memory[i][`MEM_CURRENT]),
                       .step_count(step_encoder[i]));
       end
     endgenerate
@@ -351,8 +351,10 @@ module spi_state_machine #(
       encoder_store[nmot] <= 0;
 
       // Stepper Config
-      microsteps[nmot] <= default_microsteps;
-      current[nmot] <= default_current;
+      config_memory[nmot][`MEM_MICROSTEPS] <= default_microsteps;
+      config_memory[nmot][`MEM_CURRENT] <= default_current;
+
+      // Microstepper config
       config_offtime[nmot] <= 810;
       config_blanktime[nmot] <= 27;
       config_fastdecay_threshold[nmot] <= 706;
@@ -411,8 +413,7 @@ module spi_state_machine #(
           // Set Microstepping
           `CMD_MOTORCONFIG: begin
             // TODO needs to be power of two
-            current[word_data_received[55:48]][7:0] <= word_data_received[15:8];
-            microsteps[word_data_received[55:48]][2:0] <= word_data_received[2:0];
+            config_memory[word_data_received[55:48]] <= word_data_received[15:0];
           end
 
           // Set Microstepping Parameters

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -133,8 +133,8 @@ module spi_state_machine #(
   // Stepper Configs
   //
 
-  reg [15:0] config_memory [0:motor_count-1]; // [15:8] -> microsteps [7:0] current
-
+  reg [7:0] microsteps [0:motor_count-1];
+  reg [7:0] current [0:motor_count-1];
   reg [9:0] config_offtime [0:motor_count-1];
   reg [7:0] config_blanktime [0:motor_count-1];
   reg [9:0] config_fastdecay_threshold [0:motor_count-1];
@@ -166,8 +166,8 @@ module spi_state_machine #(
                       .dir (dir[i]),
                       .enable (enable[i]),
                       .brake  (brake[i]),
-                      .microsteps (config_memory[i][`MEM_MICROSTEPS]),
-                      .current (config_memory[i][`MEM_CURRENT]),
+                      .microsteps (microsteps[i]),
+                      .current (current[i]),
                       .step_count(step_encoder[i]));
       end
     endgenerate
@@ -351,10 +351,8 @@ module spi_state_machine #(
       encoder_store[nmot] <= 0;
 
       // Stepper Config
-      config_memory[nmot][`MEM_MICROSTEPS] <= default_microsteps;
-      config_memory[nmot][`MEM_CURRENT] <= default_current;
-
-      // Microstepper config
+      microsteps[nmot] <= default_microsteps;
+      current[nmot] <= default_current;
       config_offtime[nmot] <= 810;
       config_blanktime[nmot] <= 27;
       config_fastdecay_threshold[nmot] <= 706;
@@ -413,7 +411,8 @@ module spi_state_machine #(
           // Set Microstepping
           `CMD_MOTORCONFIG: begin
             // TODO needs to be power of two
-            config_memory[word_data_received[55:48]] <= word_data_received[15:0];
+            current[word_data_received[55:48]][7:0] <= word_data_received[15:8];
+            microsteps[word_data_received[55:48]][2:0] <= word_data_received[2:0];
           end
 
           // Set Microstepping Parameters


### PR DESCRIPTION
After working to get BRAM inference working... it now works too well. The problem is it does not always pick the most efficient things to store (it almost seems random). Since we also have relatively short memory lengths == motor_count or motor_count*buffer_length, we can bit pack things together and try to colocate data.