### PR TITLE
Add SV Lint and minor opt to PWM

### DIFF
--- a/.svlint.toml
+++ b/.svlint.toml
@@ -1,0 +1,2 @@
+[rules]
+wire_reg = false

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ verilator-cdc: $(RAPCOREFILES)
 
 triple-check: yosys-parse iverilog-parse verilator-cdc
 
+svlint: $(RAPCOREFILES)
+	svlint $(RAPCOREFILES)
+
 vvp: $(RAPCOREFILES)
 	iverilog -tvvp $(RAPCOREFILES)
 

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,7 @@ let
   buildInputs = with pkgs;
     # these are generally useful packages for tests, verification, synthesis
     # and deployment, etc
-    [ yosys verilog verilator symbiyosys nextpnr icestorm trellis
+    [ yosys verilog verilator svlint symbiyosys nextpnr icestorm trellis
       yices tinyprog fujprog openocd
     ];
 

--- a/src/pwm.v
+++ b/src/pwm.v
@@ -4,7 +4,8 @@
  Simple PWM module
 */
 module pwm #(
-    parameter bits = 8
+    parameter bits = 8,
+    parameter resetable = 0
 ) (
     input  clk,
     input  resetn,
@@ -12,13 +13,15 @@ module pwm #(
     output pwm
 );
 
-  reg [bits-1:0] accum;
+  reg [bits-1:0] accum = 0;
   assign pwm = (accum < val);
 
   always @(posedge clk)
-  if(!resetn)
-    accum <= 0;
-  else if(resetn)
+  if (resetable) begin
+    if(!resetn) accum <= 0;
+    else if(resetn) accum <= accum + 1'b1;
+  end else
     accum <= accum + 1'b1;
+
 
 endmodule

--- a/src/pwm.v
+++ b/src/pwm.v
@@ -13,7 +13,7 @@ module pwm #(
     output pwm
 );
 
-  reg [bits-1:0] accum = 0;
+  reg [bits-1:0] accum = 0; // FPGA ONLY
   assign pwm = (accum < val);
 
   always @(posedge clk)

--- a/src/spi.v
+++ b/src/spi.v
@@ -61,7 +61,7 @@ module SPI (
           rx_byte <= {rx_byte[6:0], COPI_data};
 
           // Trigger Byte recieved
-          rx_byte_ready_r <= (&rxbitcnt[2:0]);
+          rx_byte_ready_r <= &rxbitcnt;
         end
 
         // Transmit increment


### PR DESCRIPTION
This squeezes a bit more out of the PWM module by allowing reset to be disabled via parameter. In theory PWM should be held low by the value reset at the top level. 

Also add SVLint as another linter. 