### PR TITLE
RFC: change to a modular edge detector imported from tinyfpga bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ BUILDDIR = ./build/
 BUILD = $(BUILDDIR)$(BOARD)
 RAPCOREFILES := boards/$(BOARD)/$(BOARD).v \
 								$(addprefix src/, clock_divider.v \
+														edge_detector.v \
 													  macro_params.v \
 														spi_state_machine.v \
 														pwm.v \

--- a/src/dda_timer.v
+++ b/src/dda_timer.v
@@ -16,15 +16,16 @@ module dda_timer(
 
   // Step Trigger condition
   reg step_r;
-  reg [1:0] dda_tick_r;
+  wire dda_tick_rising;
   assign step = step_r;
+
+  rising_edge_detector dda_rising (.clk(CLK), .in(dda_tick), .out(dda_tick_rising));
 
   always @(posedge CLK) if (!resetn) begin
 
     substep_accumulator <= 64'b0; // typemax(Int64) - 100 for buffer
     increment_r <= 64'b0;
     step_r <= 0;
-    dda_tick_r <= 0;
 
   end else if (resetn) begin
 
@@ -33,8 +34,7 @@ module dda_timer(
       increment_r <= increment;
     end
 
-    dda_tick_r <= {dda_tick_r[0], dda_tick};
-    if(dda_tick_r == 2'b01) begin
+    if(dda_tick_rising) begin
 
       // Step taken, rollback accumulator
       if (substep_accumulator > 0) begin

--- a/src/dual_hbridge.v
+++ b/src/dual_hbridge.v
@@ -91,16 +91,15 @@ module dual_hbridge #(
 
   reg [7:0] phase_ct;
 
-  reg [1:0] step_r;
+  wire step_rising;
+  rising_edge_detector step_r (.clk(clk), .in(step), .out(step_rising));
 
   always @(posedge clk) begin
     if (!resetn) begin
-      step_r <= 2'b0;
+      phase_ct <= 8'b0;
     end else if (resetn) begin
-      step_r <= {step_r[0], step};
-
       // Traverse the table based on direction, rolls over
-      if (step_r == 2'b01) begin // rising edge
+      if (step_rising) begin // rising edge
         phase_ct <= phase_ct + phase_inc;
         count_r <= count_r + phase_inc;
       end

--- a/src/edge_detector.v
+++ b/src/edge_detector.v
@@ -1,0 +1,30 @@
+// Source: https://github.com/tinyfpga/TinyFPGA-Bootloader
+// Apache 2.0
+
+module rising_edge_detector ( 
+  input clk,
+  input in,
+  output out
+);
+  reg in_q;
+
+  always @(posedge clk) begin
+    in_q <= in;
+  end
+
+  assign out = !in_q && in;
+endmodule
+
+module falling_edge_detector ( 
+  input clk,
+  input in,
+  output out
+);
+  reg in_q;
+
+  always @(posedge clk) begin
+    in_q <= in;
+  end
+
+  assign out = in_q && !in;
+endmodule

--- a/src/spi.v
+++ b/src/spi.v
@@ -116,18 +116,18 @@ module SPIWord (
 
   reg [2:0] byte_count;
   wire [7:0] word_slice [7:0]; // slice the register into 8 bits
-  reg [1:0] rx_byte_ready_r;
+  wire rx_byte_ready_rising;
   reg word_received_r;
+
+  rising_edge_detector ready_rising (.clk(clk), .in(rx_byte_ready), .out(rx_byte_ready_rising));
 
   // Recieve Shift Register
   always @(posedge clk) if (!resetn) begin
     word_data_received <= 64'b0;
     byte_count <= 0;
-    rx_byte_ready_r <= 2'b0;
     word_received_r <= 0;
   end else if (resetn) begin
-    rx_byte_ready_r <= {rx_byte_ready_r[0], rx_byte_ready};
-    if (rx_byte_ready_r == 2'b01) begin
+    if (rx_byte_ready_rising) begin
       byte_count <= byte_count + 1'b1;
       word_data_received <= {rx_byte[7:0], word_data_received[63:8]};
       if (byte_count == 3'b111) word_received_r <= 1'b1;

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -331,7 +331,7 @@ module spi_state_machine #(
                              (message_header == CMD_ENCODERFAULT);
 
   wire word_received_rising;
-  rising_edge_detector step_r (.clk(CLK), .in(word_received), .out(word_received_rising));
+  rising_edge_detector word_recieved_edge_rising (.clk(CLK), .in(word_received), .out(word_received_rising));
 
   reg [7:0] nmot;
 

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -329,7 +329,9 @@ module spi_state_machine #(
                              (message_header == CMD_API_VERSION) |
                              (message_header == CMD_STEPPERFAULT) |
                              (message_header == CMD_ENCODERFAULT);
-  reg [1:0] word_received_r;
+
+  wire word_received_rising;
+  rising_edge_detector step_r (.clk(CLK), .in(word_received), .out(word_received_rising));
 
   reg [7:0] nmot;
 
@@ -353,8 +355,6 @@ module spi_state_machine #(
     clock_divisor <= default_clock_divisor;  // should be 40 for 400 khz at 16Mhz Clk
     message_word_count <= 0;
     message_header <= 0;
-
-    word_received_r <= 2'b0;
 
     // TODO change to for loops for buffer
     move_duration[0] <= 0;
@@ -385,8 +385,7 @@ module spi_state_machine #(
     /* verilator lint_off WIDTH */
 
   end else if (resetn) begin
-    word_received_r <= {word_received_r[0], word_received};
-    if (word_received_r == 2'b01) begin
+    if (word_received_rising) begin
       // Zero out send data register
       word_send_data <= 64'b0;
 

--- a/symbiyosys/symbiyosys.sby
+++ b/symbiyosys/symbiyosys.sby
@@ -10,6 +10,7 @@ read -formal macro_params.v
 read -formal clock_divider.v
 read -formal dda_fsm.v
 read -formal dda_timer.v
+read -formal edge_detector.v
 read -formal spi.v
 read -formal dual_hbridge.v
 read -formal quad_enc.v
@@ -34,6 +35,7 @@ src/macro_params.v
 src/clock_divider.v
 src/dda_fsm.v
 src/dda_timer.v
+src/edge_detector.v
 src/spi.v
 src/dual_hbridge.v
 src/spi_state_machine.v


### PR DESCRIPTION
Found this while reading the tinyfpga bootloader code. It seems like a marginally more efficient and uniform way to do rising and falling edge detection. Placing in the FSM, SPI, and HBridge saved ~20LUT.

RFC:
The idiom is a little different than our shift register.
Likely still a good idea to DRY out edge detection via a module.
