### PR TITLE
WIP experiment: orthogonal holding mode

### DIFF
--- a/src/dual_hbridge.v
+++ b/src/dual_hbridge.v
@@ -95,13 +95,13 @@ module dual_hbridge #(
   wire step_rising;
   rising_edge_detector step_r (.clk(clk), .in(step), .out(step_rising));
   reg phase_flip;
-  reg [4:0] flip_accum;
+  reg [9:0] flip_accum;
 
   always @(posedge clk) begin
     if (!resetn) begin
       phase_ct <= 8'b0;
       phase_flip <= 1'b0;
-      flip_accum <= 5'b0;
+      flip_accum <= 10'b0;
     end else if (resetn) begin
       // Traverse the table based on direction, rolls over
       if (step_rising) begin // rising edge
@@ -111,8 +111,8 @@ module dual_hbridge #(
 
       // Weird drive mode
       if (&flip_accum) begin
-        if (phase_flip) phase_ct <= phase_ct - 8'd50;
-        else phase_ct <= phase_ct + 8'd50;
+        if (phase_flip) phase_ct <= phase_ct - 8'd40;
+        else phase_ct <= phase_ct + 8'd40;
         phase_flip <= !phase_flip;
       end
       flip_accum <= flip_accum + 1'b1;

--- a/src/dual_hbridge.v
+++ b/src/dual_hbridge.v
@@ -94,16 +94,28 @@ module dual_hbridge #(
 
   wire step_rising;
   rising_edge_detector step_r (.clk(clk), .in(step), .out(step_rising));
+  reg phase_flip;
+  reg [4:0] flip_accum;
 
   always @(posedge clk) begin
     if (!resetn) begin
       phase_ct <= 8'b0;
+      phase_flip <= 1'b0;
+      flip_accum <= 5'b0;
     end else if (resetn) begin
       // Traverse the table based on direction, rolls over
       if (step_rising) begin // rising edge
         phase_ct <= phase_ct + phase_inc;
         count_r <= count_r + phase_inc;
       end
+
+      // Weird drive mode
+      if (&flip_accum) begin
+        if (phase_flip) phase_ct <= phase_ct - 8'd50;
+        else phase_ct <= phase_ct + 8'd50;
+        phase_flip <= !phase_flip;
+      end
+      flip_accum <= flip_accum + 1'b1;
 
       // Load sine/cosine from RAM
       phase_a <= phase_table[phase_ct+8'd64];


### PR DESCRIPTION
Dirty hack to try this. The basic idea is to alternate the current periodically at +/-90 degrees (slightly less seems to be better) to the given magnetic field orientation. This shouldn't necessarily change the holding torque but rather reduce the amount of springiness in the system when at a standstill. By changing the angle we alternate at we can change this "spring constant" on the fly. Initial tests on the dial are promising, but will obviously need more work to validate, quantify and expose in a sensible way.