### PR TITLE
ALERT/WIP: Verilator Width Linting was incorrectly reenabled

### DIFF
--- a/src/quad_enc.v
+++ b/src/quad_enc.v
@@ -8,12 +8,8 @@ module quad_enc #(
   input wire  clk,
   input wire  a,
   input wire  b,
-  input wire  i,
   output reg faultn,
-  output reg signed [encbits-1:0] count,
-  output wire step_a,
-  output wire step_b,
-  output wire step_i
+  output reg signed [encbits-1:0] count
   //input [7:0] multiplier
   );
 
@@ -21,9 +17,8 @@ module quad_enc #(
 
   reg [2:0] a_stable, b_stable, i_stable;  //Hold sample before compare for stability
 
-  assign step_a = a_stable[1] ^ a_stable[2];  //Step if a changed
-  assign step_b = b_stable[1] ^ b_stable[2];  //Step if b changed
-  assign step_i = i_stable[1] ^ i_stable[2];  //Step if b changed
+  wire step_a = a_stable[1] ^ a_stable[2];  //Step if a changed
+  wire step_b = b_stable[1] ^ b_stable[2];  //Step if b changed
   wire step = step_a ^ step_b;  //Step if a xor b stepped
   wire direction = a_stable[1] ^ b_stable[2];  //Direction determined by comparing current sample to last
 
@@ -37,7 +32,6 @@ module quad_enc #(
     else begin
       a_stable <= {a_stable[1:0], a};  //Shift new a in. Last 2 samples shift to bits 2 and 1
       b_stable <= {b_stable[1:0], b};  //Shift new b in
-      i_stable <= {i_stable[1:0], i};
 
       if (step_a && step_b)  //We do not know direction if both inputs triggered on single clock
         faultn <= 0;

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -257,7 +257,6 @@ module spi_state_machine #(
 
   if(num_encoders > 0) begin
     for (i=0; i<num_encoders; i=i+1) begin
-      /* verilator lint_off PINMISSING */
       quad_enc #(.encbits(encoder_bits)) encoder0
       (
         .resetn(resetn),
@@ -268,7 +267,6 @@ module spi_state_machine #(
         .count(encoder_count[i])
         //.multiplier(encoder_multiplier)
         );
-        /* verilator lint_on PINMISSING */
     end
   end
 
@@ -368,7 +366,6 @@ module spi_state_machine #(
     move_duration[0] <= 0;
     move_duration[1] <= 0;
 
-    /* verilator lint_off WIDTH */
     for (nmot=0; nmot<num_motors; nmot=nmot+1) begin
       increment[0][nmot] <= {dda_bits{1'b0}};
       increment[1][nmot] <= {dda_bits{1'b0}};
@@ -390,7 +387,6 @@ module spi_state_machine #(
       config_invert_highside[nmot] <= `DEFAULT_BRIDGE_INVERTING;
       config_invert_lowside[nmot] <= `DEFAULT_BRIDGE_INVERTING;
     end
-    /* verilator lint_on WIDTH */
 
   end else if (resetn) begin
     if (word_received_rising) begin

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -336,7 +336,7 @@ module spi_state_machine #(
                              (message_header == CMD_STEPPERFAULT) |
                              (message_header == CMD_ENCODERFAULT);
 
-  wire header_motor_channel = word_data_received[(48+$clog2(num_motors)):48];
+  wire [$clog2(num_motors-1):0] header_motor_channel = word_data_received[(48+$clog2(num_motors)):48];
 
 
   wire word_received_rising;
@@ -441,6 +441,9 @@ module spi_state_machine #(
             // TODO needs to be power of two
             current[header_motor_channel][7:0] <= word_data_received[15:8];
             microsteps[header_motor_channel][2:0] <= word_data_received[2:0];
+            `ifdef FORMAL
+              assert(header_motor_channel == word_data_received[(48+$clog2(num_motors)):48]);
+            `endif
           end
 
           // Set Microstepping Parameters

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -513,17 +513,17 @@ module spi_state_machine #(
               if (nmot == 0) begin
                 if (message_word_count == 1) begin
                   move_duration[writemoveind][move_duration_bits-1:0] <= word_data_received[move_duration_bits-1:0];
-                  word_send_data <= step_encoder_store[0]; // Prep to send steps
+                  word_send_data[encoder_bits-1:0] <= step_encoder_store[0]; // Prep to send steps
                 end
               end
 
               if (message_word_count == (nmot+1)*2) begin
                 increment[writemoveind][nmot] <= word_data_received;
-                word_send_data <= encoder_store[nmot]; // Prep to send steps
+                word_send_data[encoder_bits-1:0] <= encoder_store[nmot]; // Prep to send steps
               end
               if (message_word_count == (nmot+1)*2+1) begin
                 incrementincrement[writemoveind][nmot] <= word_data_received;
-                if (nmot != num_motors-1) word_send_data <= step_encoder_store[nmot+1]; // Prep to send steps
+                if (nmot != num_motors-1) word_send_data[encoder_bits-1:0] <= step_encoder_store[nmot+1]; // Prep to send steps
 
                 if (nmot == num_motors-1) begin
                   writemoveind <= writemoveind + 1'b1;

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -153,7 +153,7 @@ module spi_state_machine #(
 
   wire [num_motors-1:0] stepper_faultn; // stepper fault
 
-  wire [31:0] step_encoder [num_motors-1:0]; // step encoder
+  wire [encoder_bits-1:0] step_encoder [num_motors-1:0]; // step encoder
 
   //
   // Stepper Configs

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -268,7 +268,7 @@ module spi_state_machine #(
         .count(encoder_count[i])
         //.multiplier(encoder_multiplier)
         );
-        /* verilator lint_off PINMISSING */
+        /* verilator lint_on PINMISSING */
     end
   end
 
@@ -341,7 +341,7 @@ module spi_state_machine #(
   wire word_received_rising;
   rising_edge_detector word_recieved_edge_rising (.clk(CLK), .in(word_received), .out(word_received_rising));
 
-  reg [7:0] nmot;
+  reg [$clog2(num_motors):0] nmot;
 
   always @(posedge CLK) if (!resetn) begin
 
@@ -390,7 +390,7 @@ module spi_state_machine #(
       config_invert_highside[nmot] <= `DEFAULT_BRIDGE_INVERTING;
       config_invert_lowside[nmot] <= `DEFAULT_BRIDGE_INVERTING;
     end
-    /* verilator lint_off WIDTH */
+    /* verilator lint_on WIDTH */
 
   end else if (resetn) begin
     if (word_received_rising) begin


### PR DESCRIPTION
We had:
```
     /* verilator lint_off WIDTH */

code...

     /* verilator lint_off WIDTH */
```
Where we needed:
```
     /* verilator lint_off WIDTH */

code...

     /* verilator lint_on WIDTH */
```