### PR TITLE
[spi] fix preload issue

### DIFF
--- a/src/edge_detector.v
+++ b/src/edge_detector.v
@@ -42,7 +42,7 @@ module rising_edge_detector_tribuf (
     in_q <= {in_q[1:0], in};
   end
 
-  assign out = (in_q == 3'b001);
+  assign out = (in_q[2:1] == 2'b01);
 endmodule
 
 module falling_edge_detector_tribuf ( 
@@ -56,5 +56,5 @@ module falling_edge_detector_tribuf (
     in_q <= {in_q[1:0], in};
   end
 
-  assign out = (in_q == 3'b100);
+  assign out = (in_q[2:1] == 2'b10);
 endmodule

--- a/src/spi.v
+++ b/src/spi.v
@@ -16,6 +16,7 @@ module SPI (
 
   // Registers to sync IO with FPGA clock
   reg [1:0] COPIr;
+  reg [1:0] CSr;
 
   // Output Byte and ready flag
   reg rx_byte_ready_r;
@@ -31,7 +32,7 @@ module SPI (
   rising_edge_detector_tribuf sck_rising (.clk(clk), .in(SCK), .out(SCK_risingedge));
   falling_edge_detector_tribuf sck_falling (.clk(clk), .in(SCK), .out(SCK_fallingedge));
 
-  wire CS_active = ~CS;  // active low
+  wire CS_active = ~CSr[1];  // active low
   wire COPI_data = COPIr[1];
   // CIPO pin (tristated per convention)
   assign CIPO = (CS_active) ? tx_byte[txbitcnt] : 1'bZ;
@@ -53,6 +54,7 @@ module SPI (
 
       // Use a 2 bit shift register to sync COPI with FPGA clock
       COPIr <= {COPIr[0], COPI};
+      CSr <= {CSr[0], CS};
 
       if (CS_active) begin
         // Recieve increment on rising edge

--- a/src/spi.v
+++ b/src/spi.v
@@ -60,14 +60,13 @@ module SPI (
           rxbitcnt <= rxbitcnt + 1'b1;
           // Shift in Recieved bits
           rx_byte <= {rx_byte[6:0], COPI_data};
-
-          // Trigger Byte recieved
-          rx_byte_ready_r <= &rxbitcnt;
         end
 
         // Transmit increment
         if (SCK_fallingedge) begin
           txbitcnt <= txbitcnt - 1'b1; // rolls over
+          // Trigger Byte recieved
+          rx_byte_ready_r <= (txbitcnt == 3'b0);
         end
 
         //`ifdef FORMAL

--- a/src/spi.v
+++ b/src/spi.v
@@ -62,10 +62,7 @@ module SPI (
           rxbitcnt <= rxbitcnt + 1'b1;
           // Shift in Recieved bits
           rx_byte <= {rx_byte[6:0], COPI_data};
-        end
-
-        // Transmit increment
-        if (SCK_fallingedge) begin
+        end else if (SCK_fallingedge) begin
           txbitcnt <= txbitcnt - 1'b1; // rolls over
           // Trigger Byte recieved
           rx_byte_ready_r <= (txbitcnt == 3'b0);


### PR DESCRIPTION
This is ~partial~ an RCA on SPI issues:

![Screenshot from 2021-04-07 23-11-41](https://user-images.githubusercontent.com/2086412/114064003-34cf8200-9867-11eb-9708-1ce1536ef59b.png)

Note we are sending the following sequence: {0x02, 0x00, 0x01}, but three CIPO pulses are present. The erroneous pulse occurs due to signalling complete transfer at the rising edge (when we read). Since the FSM is only a cycle or two, we end up loading the next word half way through sending the last bit (generally in Mode 0 Transfer CIPO state exist for a whole period, whereas receive is during the high half of a clock period). By waiting until the falling edge to signal a complete transfer we correct our mode 0 behavior. This does not completely address SPI issues, but it has put the errors into two main categories: True and NACK. Before we would have randomly wrong reads in the last bit of a byte due to the wrong behavior. 

*Update:*

The first fix revealed that we have metastability somewhere, since we were reading + writing correctly. This was validated by readback of the received word. This showed the system was reading the sent word + header correctly, was was not entering the FSM correctly. Initial throught was that the FSM must be metastable. After a refactor to make the machine "one hot" this did not fix. After closer investigation of the signals the only potentially metastable signal was the chip select - CS. Sure enough, by clocking this signal in error rates went to zero. 

To be completely frank I do not understand yet how this would propagate though the logic, because as I see it now, this should not be the case. The most likely effect would be `rx_byte_ready_r` inside spi violating setup times. Regardless, the lesson learned in every input signal should be clocked in + buffered.

I am running extended tests with these patches. A 30 minute tests has shown no errors at 1Mhz. I will run a multi-hour test over night for additional validation.