### PR TITLE
CI adjustments, drop Verilator linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,19 +13,13 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: TinyFPGABX Flow
-      run: nix-shell --command 'make BOARD=tinyfpgabx'
+      run: nix-shell --command 'make build-full -j4 BOARD=tinyfpgabx'
     - name: ULX3S Flow
-      run: nix-shell --command 'make BOARD=ulx3s'
+      run: nix-shell --command 'make build-full -j4 BOARD=ulx3s'
     - name: RAPBo Flow
-      run: nix-shell --command 'make BOARD=rapbo'
+      run: nix-shell --command 'make build-full -j4 BOARD=rapbo'
     - name: ECP5 Eval Flow
-      run: nix-shell --command 'make BOARD=ecp5evn'
-    - name: Formal Verification
-      run: nix-shell --command 'make formal'
-    - name: iverilog parse compat
-      run: nix-shell --command 'make iverilog-parse'
-    - name: verilator CDC
-      run: nix-shell --command 'make verilator-cdc'
+      run: nix-shell --command 'make build-full -j4 BOARD=ecp5evn'
     - name: reg initialization
       run: ./etc/reginit.sh
 

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ ifeq ($(ARCH), gowin)
 	gowin_pack $(PACK_FLAGS) -o $(BUILD).bit $(BUILD).json
 endif
 
+build-full: build logs iverilog-parse formal $(BUILD).bit
 
 logs:
 	mkdir -p logs

--- a/src/rapcore.v
+++ b/src/rapcore.v
@@ -184,17 +184,6 @@ module rapcore #(
     `ifdef LA_OUT
       .LA_OUT(LA_OUT),
     `endif
-    .CLK(CLK),
-    .pwm_clock(pwm_clock),
-    .resetn(resetn),
-
-    .word_data_received(word_data_received),
-    .word_send_data(word_send_data),
-    .word_received(word_received),
-
-    .buffer_dtr(BUFFER_DTR),
-    .move_done(MOVE_DONE),
-    .halt(HALT),
 
   `ifdef DUAL_HBRIDGE
     .PHASE_A1(PHASE_A1),  // Phase A
@@ -237,8 +226,21 @@ module rapcore #(
     `ifdef STEPOUTPUT
       .STEPOUTPUT(STEPOUTPUT),
       .DIROUTPUT(DIROUTPUT),
-      .ENOUTPUT(ENOUTPUT)
+      .ENOUTPUT(ENOUTPUT),
     `endif
+
+    .CLK(CLK),
+    .pwm_clock(pwm_clock),
+    .resetn(resetn),
+
+    .word_data_received(word_data_received),
+    .word_send_data(word_send_data),
+    .word_received(word_received),
+
+    .buffer_dtr(BUFFER_DTR),
+    .move_done(MOVE_DONE),
+    .halt(HALT)
+
   );
 
 

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -178,7 +178,6 @@ module spi_state_machine #(
   //
 
   `ifdef DUAL_HBRIDGE
-    genvar i;
     generate
       for (i=0; i<num_motors; i=i+1) begin
         dual_hbridge #(.step_count_bits(encoder_bits))
@@ -259,7 +258,7 @@ module spi_state_machine #(
   wire [num_encoders-1:0] encoder_faultn;
   wire [31:0] encoder_velocity [num_encoders-1:0];
 
-  if(num_encoders > 0) begin
+  `ifdef QUAD_ENC
     for (i=0; i<num_encoders; i=i+1) begin
       quad_enc #(.encbits(encoder_bits),
                  .velocity_bits(encoder_velocity_bits)) encoder0
@@ -274,7 +273,7 @@ module spi_state_machine #(
         //.multiplier(encoder_multiplier)
         );
     end
-  end
+  `endif
 
 
   wire loading_move;
@@ -483,8 +482,9 @@ module spi_state_machine #(
           end
 
           // Read Stepper fault register
+
           CMD_ENCODERFAULT: begin
-            word_send_data[num_encoders-1:0] <= ~encoder_faultn;
+            if (num_encoders > 0) word_send_data[num_encoders-1:0] <= ~encoder_faultn;
           end
 
 

--- a/symbiyosys/symbiyosys.sby
+++ b/symbiyosys/symbiyosys.sby
@@ -19,6 +19,7 @@ read -formal pwm_pll.v
 read -formal spi_state_machine.v
 read -formal microstepper_top.v
 read -formal microstepper_control.v
+read -formal space_vector_modulator.v
 read -formal analog_out.v
 read -formal chargepump.v
 read -formal cosine.v
@@ -43,6 +44,7 @@ src/rapcore.v
 src/quad_enc.v
 src/pwm.v
 src/sim/pwm_pll.v
+src/space_vector_modulator.v
 src/microstepper/microstepper_top.v
 src/microstepper/microstepper_control.v
 src/microstepper/analog_out.v


### PR DESCRIPTION
This adds a `build-full` target to our makefile now used on CI. This does the following:
- Formally verifies all target configs
- Verifies yosys/iverilog compatibility
- Generates a FPGA bitstream
- Allows make to parallelize the above

Note: we now have dropped verilator lining from CI.

While verilator is an immensely helpful tool for linting and sim, it's code elaboration does not handle unreachable code blocked by parametric `if` blocks in the linting process. This leads to many false positives with parametric modules and confusion. It is to the point now it is slowing down progress and not suitable for our QA without reverting to macro spaghetti. See [this](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-884-complex-digital-systems-spring-2005/related-resources/parameter_models.pdf) for why that is not a good idea. Moreover, our only in-tree testbench support is for Yosys, CXXRTL, and IVerilog, making QA'ed Verilator support dubious. This is however a known issue by the Verilator team and seems likely to be addressed in the future. 

See:
https://github.com/verilator/verilator/issues/1540
https://github.com/verilator/verilator/issues/2866
