### PR TITLE
init gray code utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ RAPCOREFILES := boards/$(BOARD)/$(BOARD).v \
 														dual_hbridge.v \
 														dda_timer.v \
 														rapcore.v) \
-								$(wildcard src/microstepper/*.v)
+								$(wildcard src/microstepper/*.v)\
+								$(wildcard src/gray_code/*.v)
 GENERATEDFILES := src/generated/spi_pll.v src/generated/pwm_pll.v
 
 all: $(BUILD).bit

--- a/src/gray_code/bin_to_gray.v
+++ b/src/gray_code/bin_to_gray.v
@@ -1,0 +1,11 @@
+module bin_to_gray #(
+  parameter bits = 4
+) (
+  input wire [bits-1:0] bin_in,
+  output wire [bits-1:0] gray_out
+);
+    genvar i;
+    assign gray_out[bits-1] = bin_in[bits-1];
+    for (i=bits-1; i>0; i = i - 1)
+        assign gray_out[i-1] = bin_in[i] ^ bin_in[i - 1];
+endmodule

--- a/src/gray_code/gray_count.v
+++ b/src/gray_code/gray_count.v
@@ -1,0 +1,15 @@
+module gray_count #(
+    parameter bits = 4
+  ) (
+    input clk,
+    output wire [bits-1:0] gray_count
+  );
+
+  reg [bits-1:0] cnt_gray = 0;
+  assign gray_count = cnt_gray;
+
+  wire [bits-1:0] cnt_cc = {cnt_cc[bits-2:1] & ~cnt_gray[bits-3:0], ^cnt_gray, 1'b1};  // carry-chain type logic
+  always @(posedge clk) begin
+    cnt_gray <= cnt_gray ^ cnt_cc ^ cnt_cc[bits-1:1];
+  end
+endmodule

--- a/src/gray_code/gray_to_bin.v
+++ b/src/gray_code/gray_to_bin.v
@@ -1,0 +1,19 @@
+module gray_to_bin #(
+  parameter   bits = 4
+) (
+  input  wire  [bits-1:0]   gray_in,
+  output wire  [bits-1:0]   bin_out
+);
+ 
+  genvar i;
+
+
+  assign bin_out[bits-1] = gray_in[bits-1];
+
+  generate
+  for (i=bits-2; i >= 0; i=i-1) begin
+    assign bin_out[i] = ^gray_in[bits-1:i];
+  end
+  endgenerate
+      
+endmodule

--- a/testbench/gray_count_tb.v
+++ b/testbench/gray_count_tb.v
@@ -1,0 +1,17 @@
+
+module gray_count_tb(input  wire clk,
+              input  wire resetn,
+              output wire [5:0] gray_count,
+              output wire [5:0] bin_count);
+
+  gray_count #(.bits(6)) gc0 (.clk(clk),
+          //.resetn (resetn),
+          .gray_count(gray_count));
+
+  gray_to_bin #(.bits(6)
+  ) gb0 (
+  .gray_in(gray_count),
+  .bin_out(bin_count)
+);
+
+endmodule

--- a/testbench/yosys/gray_count.ys
+++ b/testbench/yosys/gray_count.ys
@@ -1,0 +1,5 @@
+
+read_verilog -sv testbench/gray_count_tb.v
+hierarchy -check -top gray_count_tb
+prep -top gray_count_tb
+sim -n 10000 -clock clk -resetn resetn -vcd testbench/vcd/gray_count.vcd


### PR DESCRIPTION
This adds some gray code utilities that are likely to be useful in the future for absolute encoder interfaces.

I've been studying high speed counters for our ADC and PWM applications, and gray codes kept popping up. I attempted a PWM based on gray code counting here: https://github.com/RAPcores/rapcores/tree/sjk/gray_pwm1

The results have so far not been good. I suspect this is due to binary<->gray conversions, and some other bugs. What I've seen recommended is to put a flip flop on each cycle rather than a continuous comparison as we do now. It is also hard to tell if gray counting is even beneficial on modern FPGA architectures and flows.

I'm putting this up as-is since the conversion modules should be useful and it may be worth revisiting in the future if we need some extra speed or resolution.