### PR TITLE
Register Mapping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: TinyFPGABX Flow
-      run: nix-shell --command 'make build-full -j4 BOARD=tinyfpgabx'
+      run: nix-shell --command 'make build-full BOARD=tinyfpgabx'
     - name: ULX3S Flow
-      run: nix-shell --command 'make build-full -j4 BOARD=ulx3s'
+      run: nix-shell --command 'make build-full BOARD=ulx3s'
     - name: RAPBo Flow
-      run: nix-shell --command 'make build-full -j4 BOARD=rapbo'
+      run: nix-shell --command 'make build-full BOARD=rapbo'
     - name: ECP5 Eval Flow
-      run: nix-shell --command 'make build-full -j4 BOARD=ecp5evn'
+      run: nix-shell --command 'make build-full BOARD=ecp5evn'
     - name: IVerilog Compat
       run: nix-shell --command 'make iverilog-parse'
     - name: reg initialization

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: TinyFPGABX Flow
-      run: nix-shell --command 'make build-full BOARD=tinyfpgabx'
+      run: nix-shell --command 'make build-full -j4 BOARD=tinyfpgabx'
     - name: ULX3S Flow
-      run: nix-shell --command 'make build-full BOARD=ulx3s'
+      run: nix-shell --command 'make build-full -j4 BOARD=ulx3s'
     - name: RAPBo Flow
-      run: nix-shell --command 'make build-full BOARD=rapbo'
+      run: nix-shell --command 'make build-full -j4 BOARD=rapbo'
     - name: ECP5 Eval Flow
-      run: nix-shell --command 'make build-full BOARD=ecp5evn'
+      run: nix-shell --command 'make build-full -j4 BOARD=ecp5evn'
     - name: IVerilog Compat
       run: nix-shell --command 'make iverilog-parse'
     - name: reg initialization

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ formal:
 	sby -f symbiyosys/symbiyosys_$(BOARD).sby
 
 iverilog-parse: $(SIMFILES)
-	iverilog -tnull -g2012 -Wall $(SIMFILES)
+	iverilog -tnull -g2012 -E -Wall $(SIMFILES)
 
 yosys-parse: $(SIMFILES)
 	yosys -qp 'read -sv $(SIMFILES)'

--- a/docs/register_map.md
+++ b/docs/register_map.md
@@ -1,0 +1,28 @@
+# Register Map
+
+RAPcores has the following types of registers that may be used to interface with the device:
+
+- Status - Read
+- Configuration - Read/Write
+- Telemetry - Read
+- Command - Read/Write
+
+Status: Realtime data access/system state
+Configuration: Parameters for device setup
+Telemetry: Time-synced concurrent data snapshots
+Command: Sets movement segment parameters
+
+For the purposes of controlling RAPcores, the Telemetry and Command registers are used to set and observe the movements of the motors.
+In applications that use SPI, these two registers may be accessed concurrently.
+The basic operational primitive of RAPcores is a movement segment over some discrete time span. To allow for use in real-time and low-jitter
+applications, command registers are at least double buffered. Similarly, the telemetry registers are syncronized to the
+buffer switch events to allow for pathplanning correction and controls development. Telemetry registers differ from status registers
+in that Telemetry registers provide "snapshots" of stored data on some even, whereas status registers are continuously updated.
+Similarly, configuration registers take effect immediately whereas command registers are queued.
+
+
+# Config Register
+
+| Address | Description |
+
+

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -81,6 +81,9 @@ module spi_state_machine #(
 
   // Static Parameter checks
   if(encoder_bits > word_bits) $error("parameter: encoder_bits is greater than word_bits");
+  if(move_duration_bits > word_bits) $error("parameter: move_duration_bits is greater than word_bits");
+  if(word_bits < 32) $error("paramter: word_bits must be at least 32 bits");
+  if(BUFFER_SIZE%2 != 0) $error("paramter: BUFFER_SIZE must be a power of two");
 
 
   localparam CMD_COORDINATED_STEP    = 8'h01;

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -409,11 +409,7 @@ module spi_state_machine #(
 
 
   // check if the Header indicated multi-word transfer
-  wire awaiting_more_words = (message_header == CMD_COORDINATED_STEP) |
-                             (message_header == CMD_STATUS_REG) |
-                             (message_header == CMD_CONFIG_REG);
-
-  wire [$clog2(num_motors-1):0] header_motor_channel = word_data_received[(48+$clog2(num_motors)):48];
+  wire awaiting_more_words = message_header != 0;
 
   wire word_received_rising;
   rising_edge_detector word_recieved_edge_rising (.clk(CLK), .in(word_received), .out(word_received_rising));

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -399,6 +399,8 @@ module spi_state_machine #(
 
   reg [$clog2(num_motors):0] nmot;
 
+  reg [7:0] dma_addr;
+
   always @(posedge CLK) if (!resetn) begin
 
     config_chargepump_period <= 91;
@@ -476,13 +478,13 @@ module spi_state_machine #(
 
           end
 
-          CMD_CONFIG_REG: begin
-            dma_addr <= word_data_received[32:0];
+          CMD_STATUS_REG: begin
+            dma_addr <= word_data_received[7:0];
             word_send_data <= status_reg_ro[word_data_received[32:0]];
           end
 
-          CMD_STATUS_REG: begin
-            dma_addr <= word_data_received[32:0];
+          CMD_CONFIG_REG: begin
+            dma_addr <= word_data_received[7:0];
             word_send_data <= config_reg_rw[word_data_received[32:0]];
           end
 
@@ -533,7 +535,7 @@ module spi_state_machine #(
             end
           end // `CMD_COORDINATED_STEP
 
-          CMD_STATUS_REG: begin
+          CMD_CONFIG_REG: begin
             config_reg_rw[dma_addr] <= word_data_received[31:0];
             message_header <= 8'b0;
           end

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -112,7 +112,7 @@ module spi_state_machine #(
   localparam status_encoder_fault = status_encoder_position_end + 1;
   localparam status_stepper_fault = status_encoder_fault + 1;
   localparam status_encoder_velocity_start = status_stepper_fault + 1;
-  localparam status_encoder_velocity_end = status_encoder_velocity_start + num_encoders - 1;;
+  localparam status_encoder_velocity_end = status_encoder_velocity_start + num_encoders - 1;
   localparam status_reg_end = status_encoder_velocity_end;
 
   // Set Status Registers, these are reset by their respective module,

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -203,10 +203,6 @@ module spi_state_machine #(
 
   reg [num_motors:1] dir_r [MOVE_BUFFER_SIZE:0];
 
-  //reg [move_duration_bits-1:0] move_duration [MOVE_BUFFER_SIZE:0];
-  //reg signed [dda_bits-1:0] increment [MOVE_BUFFER_SIZE:0][num_motors-1:0];
-  //reg signed [dda_bits-1:0] incrementincrement [MOVE_BUFFER_SIZE:0][num_motors-1:0];
-
   // Per-axis DDA parameters
   wire [dda_bits-1:0] increment_w [num_motors-1:0];
   wire [dda_bits-1:0] incrementincrement_w [num_motors-1:0];
@@ -504,7 +500,7 @@ module spi_state_machine #(
           // Move Routine
           CMD_COORDINATED_STEP: begin
             word_send_data <= telemetry_reg_ro[message_word_count-1]; // Prep to send steps
-            config_reg_rw[writemoveind][message_word_count] <= word_data_received;
+            command_reg_rw[writemoveind][message_word_count] <= word_data_received;
             if (message_word_count == num_motors*2 + 1) begin
               message_header <= 8'b0; // Reset Message Header at the end
               message_word_count <= 0;

--- a/testbench/rapcore_harness_tb.v
+++ b/testbench/rapcore_harness_tb.v
@@ -75,7 +75,7 @@ module rapcore_harness #(
     input CLK
 );
 
-  parameter NUMWORDS = 11;
+  parameter NUMWORDS = 12;
 
   reg hi = 1;
   reg lo = 0;
@@ -132,18 +132,19 @@ module rapcore_harness #(
 
   initial begin
     //enable
-    word_data_mem[0] = 64'h0a000000000000ff;
+    word_data_mem[0] = 64'hf200000000000000;
+    word_data_mem[1] = 64'hffffffffffffffff;
     //move
-    word_data_mem[1] = 64'h01000000000000aa;
-    word_data_mem[2] = 64'h00000000005fffff;
-    word_data_mem[3] = 64'hd000000000000000;
-    word_data_mem[4] = 64'h0000000000000000;
-    word_data_mem[5] = 64'hd000000000000000;
-    word_data_mem[6] = 64'h0000000000000000;
-    word_data_mem[7] = 64'hd000000000000000;
-    word_data_mem[8] = 64'h0000000000000000;
-    word_data_mem[9] = 64'hd000000000000000;
-    word_data_mem[10] = 64'h0000000000000000;
+    word_data_mem[2] = 64'h01000000000000aa;
+    word_data_mem[3] = 64'h00000000005fffff;
+    word_data_mem[4] = 64'hd000000000000000;
+    word_data_mem[5] = 64'h0000000000000000;
+    word_data_mem[6] = 64'hd000000000000000;
+    word_data_mem[7] = 64'h0000000000000000;
+    word_data_mem[8] = 64'hd000000000000000;
+    word_data_mem[9] = 64'h0000000000000000;
+    word_data_mem[10] = 64'hd000000000000000;
+    word_data_mem[11] = 64'h0000000000000000;
 
     word_data_tb = word_data_mem[0];
     tx_byte = word_data_tb[7:0];


### PR DESCRIPTION
This is the first pass at an approach that should be gradually workable into our codebase, and sticks to some principles.

- Parametric
- Possible to derive/compute the register locations
- Segments into read-only and read-write register banks
- Does not break or obfuscate existing features

In contrast to SystemRDL or IP-XACT we don't get any free lunch for documentation or C headers. So communicating and updating will have to be manual. This was expected, hence librapcores merge and documentation in this repo. This is still an undesirable situation from maintenance perspective, so this will be a stop-gap until good software becomes available or the community comes to a standard idiom.

After a somewhat length study, `localparams` seem to be the de-jour way of handling this (e.g. Picorv32, and Caravel as consequence). The (not-often-used) ability of this mechanism is procedural generation of an interface from an instantiating module. e.g given some input `parameter`s the `localparam`s will be recomputed and made accessible through dot access in the instantiator. Again, this seems to be a hot mess everywhere I look, so we are no where near an optimal solution. But this is close enough to give some resource savings and organization to the chaos we have now. 

Note that this has not yet modified the protocol, which is where resource savings are likely to occur. This only demonstrates the proposed mechanism for achieving these savings at a later point.

Additionally our register map "width" is 32 bits here. One way to handle 64 bit DDA params will be to segment into "hi" and "lo" bits in 32 bit bus mode, with 64 bit buses allowing two concurrent 32 bit register accesses. This minimizes some cascading logic in the register map as well, leading to a simpler design. 
