### PR TITLE
remove Logic Analyizer macro interface, in favor of dot access idiom

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,7 +262,7 @@ Enables LED output. Currently unused, but useful for low-frequency visual debugg
 ## Logic Analyzer
 
 The Logic Analyzer interface allows for observation and injection of signals
-within the top-level RAPcores project without patching the core project.
+with standard pin names.
 
 ```
 `define LA_OUT <N>
@@ -282,11 +282,9 @@ Default: none/0
 
 
 
-Assignments can be done at the `BOARD.v` level
-by making a `LOGICANALYZER_MACRO` like so:
+Assignments can be done at the top level module (rapcore.v) using dot access:
 
 ```
-`define LOGICANALYZER_MACRO\
-  assign LA_OUT[1] = dir; \
-  assign LA_OUT[2] = analog_cmp2;
+assign LA_OUT[1] = spifsm.dir[1];
+assign LA_OUT[2] = spifsm.s0.phase_angle[1];
 ```

--- a/src/microstepper/microstepper_top.v
+++ b/src/microstepper/microstepper_top.v
@@ -2,12 +2,6 @@
 `default_nettype none
 
 module microstepper_top (
-    `ifdef LA_IN
-      input wire [`LA_IN:1] LA_IN,
-    `endif
-    `ifdef LA_OUT
-      output wire [`LA_OUT:1] LA_OUT,
-    `endif
     input   wire       clk,
     input   wire       resetn,
     output  wire       phase_a1_l,

--- a/src/rapcore.v
+++ b/src/rapcore.v
@@ -198,12 +198,6 @@ module rapcore #(
                       .encoder_bits(`ENCODER_BITS),
                       .use_dda(`USE_DDA)) spifsm
   (
-    `ifdef LA_IN
-      .LA_IN(LA_IN),
-    `endif
-    `ifdef LA_OUT
-      .LA_OUT(LA_OUT),
-    `endif
 
   `ifdef DUAL_HBRIDGE
     .PHASE_A1(PHASE_A1),  // Phase A
@@ -263,10 +257,5 @@ module rapcore #(
 
   );
 
-
-  // Macro external wiring statements here
-  `ifdef TOP_LA
-    `TOP_LA
-  `endif
 
 endmodule

--- a/src/spi_state_machine.v
+++ b/src/spi_state_machine.v
@@ -18,12 +18,6 @@ module spi_state_machine #(
     parameter reserved_motor_channels = 32, // Represents the motor channel length to reserve, ill advised to change
     parameter reserved_encoder_channels = 64 // Represents the encoder channel length to reserve, ill advised to change
   )(
-  `ifdef LA_IN
-    input wire [`LA_IN:1] LA_IN,
-  `endif
-  `ifdef LA_OUT
-    output wire [`LA_OUT:1] LA_OUT,
-  `endif
 
   input resetn,
 
@@ -295,12 +289,6 @@ module spi_state_machine #(
     generate
       for (i=0; i<num_motors; i=i+1) begin
         microstepper_top microstepper0(
-          `ifdef LA_IN
-            .LA_IN(LA_IN),
-          `endif
-          `ifdef LA_OUT
-            .LA_OUT(LA_OUT),
-          `endif
           .clk(CLK),
           .resetn( resetn),
           .phase_a1_l(PHASE_A1[i]),
@@ -523,11 +511,5 @@ module spi_state_machine #(
       end
     end
   end
-
-  // Macro external wiring statements here
-  `ifdef STATE_MACHINE_LA
-    `STATE_MACHINE_LA
-  `endif
-
 
 endmodule


### PR DESCRIPTION
Title. This is a lot cleaner, and injecting signals does not seem to be safe or secure behavior if it does not perceptively modify the code. This keeps the capability, but makes it more idiomatic and less convenient (which is fine, because it is a development hatch). Consequentially, using dot access we can see all the signals we want without propagating the `LA_IN`/`LA_OUT` wires though every module. In practice, this  is the idiom I have been using the past few months for debugging in test benches.